### PR TITLE
Travis wordcloud fix maybe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: packages
 apt_packages:
   - libudunits2-dev
   # Since slam requires R 3.4.0 or higher
-  - r-cran-slam
+  #- r-cran-slam
 latex: false
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: packages
 apt_packages:
   - libudunits2-dev
   # Since slam requires R 3.4.0 or higher
-  #- r-cran-slam
+  - r-cran-slam
 latex: false
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ r_packages:
   - ggraph
   - igraph
   - highcharter
+  - slam
   - wordcloud
   
 r_github_packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     grid,
     fmsb,
     wordcloud,
+    slam (>= 0.1-42),
     gridExtra,
     corrplot,
     ggraph,


### PR DESCRIPTION
Have to do some trickery to get oldrel and devel to also build on Travis but it [looks like](https://travis-ci.org/rudeboybert/fivethirtyeight/builds/353621405) this works! Other travis builds for other packages and ModernDive book are also working as of last night.